### PR TITLE
Allow user to pass string meta

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -176,7 +176,7 @@ export default ({
       <style>
         ${customCss}${renderCSS(defaultStyles)}
       </style>
-      ${renderMeta(typeof meta === 'string' ? meta : {
+      ${typeof meta === 'string' ? meta : renderMeta({
         title,
         canonicalUrl,
         ...meta,

--- a/lib/render-meta.js
+++ b/lib/render-meta.js
@@ -2,15 +2,7 @@
 
 import type { StoryMetaType } from './types';
 
-const wrapMeta = string => `<script type="application/ld+json">
-  ${string}
-</script>`;
-
 export default (storyMeta: StoryMetaType) => {
-  if (typeof storyMeta === 'string') {
-    return wrapMeta(storyMeta);
-  }
-
   const {
     title,
     canonicalUrl,
@@ -54,5 +46,7 @@ export default (storyMeta: StoryMetaType) => {
     };
   }
 
-  return wrapMeta(JSON.stringify(json));
+  return `<script type="application/ld+json">
+  ${JSON.stringify(json)}
+</script>`;
 };

--- a/lib/types.js
+++ b/lib/types.js
@@ -107,7 +107,7 @@ export type StoryAnalyticsType = {
   },
 };
 
-export type StoryMetaType = string | {
+export type StoryMetaType = {
   title?: string,
   canonicalUrl?: string,
   images?: Array<string>,
@@ -127,7 +127,7 @@ export type StoryMetaType = string | {
 
 export type StoryType = {
   title?: string,
-  meta?: StoryMetaType,
+  meta?: string | StoryMetaType,
   customCss?: string,
   defaultStyles?: { [ElementTypeType]: StylesType, },
   pages?: Array<PageType>,

--- a/test.js
+++ b/test.js
@@ -692,7 +692,7 @@ test('works with no options passed', (t) => {
 });
 
 test('works with meta passed as string', (t) => {
-  const actual = storyJsonToStamp({ meta: 'this is the bad meta' });
+  const actual = storyJsonToStamp({ meta: 'this is custom meta' });
 
   const expected = `<!doctype html>
 <html ⚡ lang="en">
@@ -761,9 +761,7 @@ test('works with meta passed as string', (t) => {
     </noscript>
     <style>
     </style>
-    <script type="application/ld+json">
-      this is the bad meta
-    </script>
+    this is custom meta
   </head>
   <body>
     <amp-story standalone></amp-story>


### PR DESCRIPTION
This is because many publishers presumably already have ways of getting/formatting their AMP meta information; we want to support that.