### PR TITLE
Add autoAdvanceAfter property to pages

### DIFF
--- a/flow-types.js
+++ b/flow-types.js
@@ -140,6 +140,7 @@ export type ElementStylesType = { [ElementTypeType]: StylesType, };
 
 type ElementCreatorType<T: ElementTypeType, S: ?StylesType, A: ?AnnotationType, P: Object> = P & {
   type: T,
+  id?: string,
   annotation?: A,
   styles?: S,
 };
@@ -262,8 +263,9 @@ export type LayerType =
   | HorizontalLayerType<*, *, *>;
 
 export type PageType<L: $ReadOnlyArray<LayerType>, A: ?AnnotationType> = {|
-  id: string,
+  id?: string,
   annotation?: A,
+  autoAdvanceAfter?: string | number,
   layers: L,
 |};
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,9 +60,7 @@ export default ({
 
       return renderTag(
         componentToHtmlTagMap.video,
-        {
-          ...props,
-        },
+        props,
         sources.map(({ source, type }) => renderTag(
           'source',
           { source, type: type.split('/').length === 1 ? `video/${type}` : type },
@@ -98,9 +96,14 @@ export default ({
     ),
   };
 
-  const renderPage = ({ id, layers }) => renderTag(
+  const renderPage = ({ id, autoAdvanceAfter, layers }, index) => renderTag(
     'amp-story-page',
-    { id },
+    {
+      id: id || `page-${index}`,
+      'auto-advance-after': typeof autoAdvanceAfter === 'number'
+        ? `${autoAdvanceAfter}s`
+        : autoAdvanceAfter,
+    },
     layers.map(({ template, ...layer }) => layerTemplateToRenderMap[template](layer)).join(''),
   );
 

--- a/test.js
+++ b/test.js
@@ -41,8 +41,8 @@ test('parsing', (t) => {
     },
     pages: [
       {
-        id: 'page-0',
         annotation: 'annotation that should be stripped',
+        autoAdvanceAfter: 5,
         layers: [
           {
             template: 'fill',
@@ -167,6 +167,7 @@ test('parsing', (t) => {
       },
       {
         id: 'page-1',
+        autoAdvanceAfter: 'this-is-a-video-id',
         layers: [
           {
             template: 'horizontal',
@@ -386,7 +387,7 @@ test('parsing', (t) => {
   </head>
   <body>
     <amp-story standalone>
-      <amp-story-page id="page-0">
+      <amp-story-page id="page-0" auto-advance-after="5s">
         <amp-story-grid-layer template="fill">
           <amp-video layout="responsive" poster="test.com/poster.jpg" loop autoplay width="900" height="1600">
             <source type="application/x-mpegURL" src="test.com/video.m3u8">
@@ -402,7 +403,7 @@ test('parsing', (t) => {
           <h6>This is a heading6</h6>
         </amp-story-grid-layer>
       </amp-story-page>
-      <amp-story-page id="page-1">
+      <amp-story-page id="page-1" auto-advance-after="this-is-a-video-id">
         <amp-story-grid-layer template="horizontal" class="s-5">
           <p>This is a paragraph<br>with two<br>newlines<br>in it</p>
         </amp-story-grid-layer>


### PR DESCRIPTION
See https://github.com/ampproject/amphtml/blob/master/extensions/amp-story/amp-story.md#auto-advance-after-optional.

Also removes requirement for pages to have ids, auto-assigning one if it isn't there.